### PR TITLE
Rename a few functions that were duplicate _inherited

### DIFF
--- a/policy/kernel/device_api.cas
+++ b/policy/kernel/device_api.cas
@@ -13,7 +13,7 @@ let devfile_class_set = [ blk_file chr_file ];
 trait resource cap_sys_rawio_checks {
     /// API for types that have CAP_SYS_RAWIO checks on read and write.
 
-    fn read_inherited(domain source) {
+    fn read(domain source) {
         allow(source, self, capability, sys_rawio);
     }
 
@@ -21,7 +21,7 @@ trait resource cap_sys_rawio_checks {
         allow(source, self, capability, sys_rawio);
     }
 
-    fn write_inherited(domain source) {
+    fn write(domain source) {
         allow(source, self, capability, sys_rawio);
     }
 
@@ -29,7 +29,7 @@ trait resource cap_sys_rawio_checks {
         allow(source, self, capability, sys_rawio);
     }
 
-    fn rw_inherited(domain source) {
+    fn rw(domain source) {
         allow(source, self, capability, sys_rawio);
     }
 

--- a/policy/kernel/file_low_api.cas
+++ b/policy/kernel/file_low_api.cas
@@ -294,7 +294,7 @@ trait resource file_api {
         }
     }
 
-    fn dontaudit_textrel_mmap_exec_inherited(domain source) {
+    fn dontaudit_textrel_mmap_exec(domain source) {
         /// Do not audit denials for mmmap() this file as read-only and executable with text relocation only if it is inherited.
         /// This function is sensitive to the files_loose_watch tunable.
 


### PR DESCRIPTION
 to define the non_inherited case, which seems to have been the intent