### PR TITLE
Change @derive argument name from strategy to parent

### DIFF
--- a/policy/kernel/device_api.cas
+++ b/policy/kernel/device_api.cas
@@ -537,7 +537,7 @@ virtual resource character_device inherits device_node, character_device_api {
 //
 
 // choose block_device functions if there is a collision
-@derive(strategy=block_device)
+@derive(parents=block_device)
 virtual resource common_block_device inherits block_device, dir, symlink {
     /// Common access patterns for block device files (blk_file object class).
     /// In most cases, this is the best choice to inherit for a block device.
@@ -728,7 +728,7 @@ virtual resource common_block_device inherits block_device, dir, symlink {
 }
 
 // choose character_device functions if there is a collision
-@derive(strategy=character_device)
+@derive(parents=character_device)
 virtual resource common_character_device inherits character_device, dir, symlink {
     /// Common access patterns for character device files (chr_file object class).
     /// In most cases, this is the best choice to inherit for a character device.

--- a/policy/kernel/file_high_api.cas
+++ b/policy/kernel/file_high_api.cas
@@ -7,7 +7,7 @@
 //
 // Common file API
 //
-@derive(strategy=file_api)
+@derive(parents=file_api)
 trait resource common_file_api inherits dir_api, file_api, symlink_api {
     /// API for common regular files (file object class).
     /// This provides common access patterns for accessing files, including directory and symlink access.
@@ -399,7 +399,7 @@ trait resource common_file_api inherits dir_api, file_api, symlink_api {
 //
 // Common Directory API
 //
-@derive(strategy=dir_api)
+@derive(parents=dir_api)
 trait resource common_dir_api inherits dir_api, symlink_api {
     /// API for common directories (dir object class).
 
@@ -620,7 +620,7 @@ trait resource common_dir_api inherits dir_api, symlink_api {
     }
 }
 
-@derive(strategy=common_pipe_api)
+@derive(parents=pipe_api)
 trait resource common_pipe_api inherits dir_api, pipe_api, symlink_api {
     /// Virtual for pipes (FIFOs, fifo_file object class).
 
@@ -849,7 +849,7 @@ trait resource common_pipe_api inherits dir_api, pipe_api, symlink_api {
     }
 }
 
-@derive(strategy=named_socket_api)
+@derive(parents=named_socket_api)
 trait resource common_named_socket_api inherits dir_api, symlink_api, named_socket_api {
     /// API for common named UNIX sockets (sock_file object class).
 
@@ -1081,7 +1081,7 @@ trait resource common_named_socket_api inherits dir_api, symlink_api, named_sock
 // Higher-level file virtuals
 //
 
-@derive(strategy=common_file_api)
+@derive(parents=common_file_api)
 virtual resource common_file inherits dir, file, symlink, common_file_api {
     /// Virtual for regular files (file object class).
     /// This provides common access patterns for accessing files,
@@ -1090,21 +1090,21 @@ virtual resource common_file inherits dir, file, symlink, common_file_api {
 
 let notcommondir_class_set = [ fifo_file file sock_file blk_file chr_file ];
 
-@derive(strategy=common_dir_api)
+@derive(parents=common_dir_api)
 virtual resource common_dir inherits dir, symlink, common_dir_api {
     /// Virtual for directories (dir object class).
     /// This provides common access patterns for accessing files,
     /// including symlink access.
 }
 
-@derive(strategy=common_pipe_api)
+@derive(parents=common_pipe_api)
 virtual resource common_pipe inherits dir, pipe, symlink, common_pipe_api {
     /// Virtual for pipes (FIFOs, fifo_file object class).
     /// This provides common access patterns for accessing pipes,
     /// including directory and symlink access.
 }
 
-@derive(strategy=common_named_socket_api)
+@derive(parents=common_named_socket_api)
 virtual resource common_named_socket inherits dir, named_socket, symlink, common_named_socket_api {
     /// Low-level virtual for named UNIX sockets (sock_file object class).
     /// This provides common access patterns for accessing named sockets,

--- a/policy/kernel/files.cas
+++ b/policy/kernel/files.cas
@@ -1072,7 +1072,7 @@ resource root_t inherits common_dir, mountpoint, noxattr_filesystem {
 
 @hint(class=[file fifo_file sock_file], hint="Runtime directories are shared. A different type should use used, e.g. foo_t.runtime, to keep data private.")
 @hint(class=dir, perm=create, hint="Runtime directories are shared. A different type should use used, e.g. foo_t.runtime, to keep data private.")
-@derive(strategy=common_dir)
+@derive(parents=common_dir)
 @alias(var_run_t)
 resource runtime_t inherits common_dir, runtimefile, mountpoint  {
     /// The runtime directory (/run and /var/run)
@@ -1222,7 +1222,7 @@ resource usr_t inherits common_file, mountpoint {
 
 @hint(class=[file fifo_file sock_file], hint="/var directories are shared. A different type should use used, e.g. foo_t.data, to keep data private.")
 @hint(class=dir, perm=create, hint="/var directories are shared. A different type should use used, e.g. foo_t.data, to keep data private.")
-@derive(strategy=common_dir)
+@derive(parents=common_dir)
 resource var_t inherits common_dir, mountpoint {
     /// The /var directory.
 
@@ -1250,7 +1250,7 @@ resource var_lib_t inherits common_dir, mountpoint {
 
 @hint(class=[file fifo_file sock_file], hint="Lock directories are shared. A different type should use used, e.g. foo_t.lock, to keep data private.")
 @hint(class=dir, perm=create, hint="Lock directories are shared. A different type should use used, e.g. foo_t.lock, to keep data private.")
-@derive(strategy=common_dir)
+@derive(parents=common_dir)
 resource var_lock_t inherits common_dir, lockfile, mountpoint {
     /// The /var/lock directory.
 
@@ -1285,7 +1285,7 @@ resource var_log_t inherits common_file, logfile, mountpoint {
 
 @hint(class=[file fifo_file sock_file], hint="Spool directories are shared. A different type should use used, e.g. foo_t.spool, to keep data private.")
 @hint(class=dir, perm=create, hint="Spool directories are shared. A different type should use used, e.g. foo_t.spool, to keep data private.")
-@derive(strategy=common_dir)
+@derive(parents=common_dir)
 resource var_spool_t inherits common_dir, spoolfile {
     /// The /var/spool directory.
 

--- a/policy/kernel/filesystem.cas
+++ b/policy/kernel/filesystem.cas
@@ -238,7 +238,7 @@ resource debugfs inherits pseudo_filesystem {
 //
 @hint(class=[file fifo_file sock_file lnk_file blk_file], hint="Only directories should have this label.")
 @hint(class=chr_file, hint="This is a generic context. A different type should use used, e.g. foo_t.pty that inherits pty, login_pty, or user_pty. The login program should use term.open_pty(), to keep data private.")
-@derive(strategy=common_dir)
+@derive(parents=common_dir)
 resource devpts_t inherits common_dir, pseudo_filesystem, mountpoint {
     file_context("/dev/pts", dir, system_u:object_r:devpts_t:s0-mls_systemhigh);
     // file_context("/dev/pts(/.*)?", any, <<none>>);
@@ -487,7 +487,7 @@ resource romfs_t inherits noxattr_filesystem {
     genfscon("cramfs", "/", any);
 }
 
-@derive(strategy=common_pipe)
+@derive(parents=common_pipe)
 resource rpc_pipefs_t inherits pseudo_filesystem, common_pipe, mountpoint {
     /// RPC filesystem for communication between the kernel and userspace.
     // file_context("/var/lib/nfs/rpc_pipefs(/.*)?", any, <<none>>);
@@ -656,7 +656,7 @@ resource vxfs_t inherits noxattr_filesystem {
 
 @hint(class=[file fifo_file sock_file], hint="Tmpfs directories are shared. A different type should use used, e.g. foo_t.tmpfs, to keep data private.")
 @hint(class=dir, perm=create, hint="Tmpfs directories are shared. A different type should use used, e.g. foo_t.tmpfs, to keep data private.")
-@derive(strategy=common_dir)
+@derive(parents=common_dir)
 resource tmpfs_t inherits xattr_filesystem, common_dir, polyinstantiate_parent {
     /// tmpfs filesystem.
 


### PR DESCRIPTION
strategy was the name in the original design, but during PR review discussion, we changed the name to parent.  Update refpolicy3 to match.