### PR TITLE
Reorder statements to work around libcascade bug

### DIFF
--- a/policy/kernel/device_api.cas
+++ b/policy/kernel/device_api.cas
@@ -4,7 +4,7 @@
 // General object class sets
 //
 
-let devfile_class_set = [ blk_file chr_file ];
+// Moved to file_low_api.cas to work around libcascade bug
 
 
 //

--- a/policy/kernel/file_low_api.cas
+++ b/policy/kernel/file_low_api.cas
@@ -12,17 +12,19 @@ let files_loose_execmod = false;
 // General object class sets
 //
 
-// All directory and file classes
-let dir_file_class_set = [ dir file_class_set ];
-
-// All non-directory file classes.
-let file_class_set = [ devfile_class_set notdevfile_class_set ];
+let devfile_class_set = [ blk_file chr_file ];
 
 // Non-device file classes.
 let notdevfile_class_set = [ fifo_file file lnk_file sock_file ];
 
 // Non-device file classes.
 let dir_notdevfile_class_set = [ dir notdevfile_class_set ];
+
+// All non-directory file classes.
+let file_class_set = [ devfile_class_set notdevfile_class_set ];
+
+// All directory and file classes
+let dir_file_class_set = [ dir file_class_set ];
 
 //
 // Low-level regular file API

--- a/policy/system/selinuxutil.cas
+++ b/policy/system/selinuxutil.cas
@@ -509,6 +509,14 @@ module selinuxutil_base {
     resource selinux_policy_t;
 }
 
+module semanage {
+    domain semanage_t;
+}
+
+module setfiles {
+    domain setfiles_t;
+}
+
 module selinuxutil {
     module checkpolicy;
     module selinuxutil_base;
@@ -518,12 +526,4 @@ module selinuxutil {
     module run_init;
     module semanage;
     module setfiles;
-}
-
-module semanage {
-    domain semanage;
-}
-
-module setfiles {
-    domain setfiles_t;
 }


### PR DESCRIPTION
Let bindings and module definitions should not be order dependent.  Due to a current libcascade bug that is expected to be carried into 0.1, they are order dependent.  Reorder to make current libcascade happy, and revert this after the bug is fixed.

https://github.com/dburgener/cascade/issues/167