### PR TITLE
Fix a couple of domain/resource confusions in module declaration

### DIFF
--- a/policy/system/auth.cas
+++ b/policy/system/auth.cas
@@ -8,7 +8,7 @@ resource auth_cache_t inherits logfile, common_sock_file {
     file_context("/var/cache/coolkey(/.*)?", any);
 }
 
-resource chkpwd_t inherits app_domain {
+domain chkpwd_t inherits app_domain {
     /// pam_unix_chkpwd
 
     extend exec {
@@ -439,7 +439,7 @@ module pam {
     domain chkpwd_t;
     domain pam_console_t;
     resource pam_motd_runtime_t;
-    resource updpwd_t;
+    domain updpwd_t;
 }
 
 module pam_timestamp {


### PR DESCRIPTION
For some reason, Cascade had been missing these, but a recent bugfix (probably https://github.com/dburgener/cascade/pull/175) caused it to start reporting these errors.