### PR TITLE
Use the empty string as a default value instead of None

### DIFF
--- a/policy/kernel/file_high_api.cas
+++ b/policy/kernel/file_high_api.cas
@@ -373,14 +373,14 @@ trait resource common_file_api inherits dir_api, file_api, symlink_api {
         this<symlink_api>.dontaudit_read(source);
     }
 
-    fn add_entry_filetrans(domain source, resource default, [class]obj_classes, string name=None) {
+    fn add_entry_filetrans(domain source, resource default, [class]obj_classes, string name="") {
         /// Create a file-like object in this directory with a private type.
         /// This does not allow deletions from the directory.
         this<dir_api>.add_entry_filetrans(source, default, obj_classes, name);
         this<symlink_api>.read(source);
     }
 
-    fn filetrans(domain source, resource default, [class]obj_classes, string name=None) {
+    fn filetrans(domain source, resource default, [class]obj_classes, string name="") {
         /// Create a file-like object in this directory with a private type.
         this<dir_api>.filetrans(source, default, obj_classes, name);
         this<symlink_api>.read(source);
@@ -598,14 +598,14 @@ trait resource common_dir_api inherits dir_api, symlink_api {
         this<symlink_api>.dontaudit_read(source);
     }
 
-    fn add_entry_filetrans(domain source, resource default, [class]obj_classes, string name=None) {
+    fn add_entry_filetrans(domain source, resource default, [class]obj_classes, string name="") {
         /// Create a file-like object in this directory with a private type.
         /// This does not allow deletions from the directory.
         allow(source, this, dir, add_entry_dir_perms);
         resource_transition(source, this, obj_classes, default, name);
     }
 
-    fn filetrans(domain source, resource default, [class]obj_classes, string name=None) {
+    fn filetrans(domain source, resource default, [class]obj_classes, string name="") {
         /// Create a file-like object in this directory with a private type.
         allow(source, this, dir, rw_dir_perms);
         resource_transition(source, this, obj_classes, default, name);
@@ -825,14 +825,14 @@ trait resource common_pipe_api inherits dir_api, pipe_api, symlink_api {
         this<symlink_api>.dontaudit_read(source);
     }
 
-    fn add_entry_filetrans(domain source, resource default, [class]obj_classes, string name=None) {
+    fn add_entry_filetrans(domain source, resource default, [class]obj_classes, string name="") {
         /// Create a file-like object in this directory with a private type.
         /// This does not allow deletions from the directory.
         allow(source, this, dir, add_entry_dir_perms);
         resource_transition(source, this, obj_classes, default, name);
     }
 
-    fn filetrans(domain source, resource default, [class]obj_classes, string name=None) {
+    fn filetrans(domain source, resource default, [class]obj_classes, string name="") {
         /// Create a file-like object in this directory with a private type.
         allow(source, this, dir, rw_dir_perms);
         resource_transition(source, this, obj_classes, default, name);
@@ -1053,14 +1053,14 @@ trait resource common_named_socket_api inherits dir_api, symlink_api, named_sock
         this<symlink_api>.dontaudit_read(source);
     }
 
-    fn add_entry_filetrans(domain source, resource default, [class]obj_classes, string name=None) {
+    fn add_entry_filetrans(domain source, resource default, [class]obj_classes, string name="") {
         /// Create a file-like object in this directory with a private type.
         /// This does not allow deletions from the directory.
         allow(source, this, dir, add_entry_dir_perms);
         resource_transition(source, this, obj_classes, default, name);
     }
 
-    fn filetrans(domain source, resource default, [class]obj_classes, string name=None) {
+    fn filetrans(domain source, resource default, [class]obj_classes, string name="") {
         /// Create a file-like object in this directory with a private type.
         allow(source, this, dir, rw_dir_perms);
         resource_transition(source, this, obj_classes, default, name);

--- a/policy/kernel/file_low_api.cas
+++ b/policy/kernel/file_low_api.cas
@@ -1149,14 +1149,14 @@ trait resource dir_api {
         dontaudit(source, this, dir, audit_access);
     }
 
-    fn add_entry_filetrans(domain source, resource default, [class]obj_classes, string name=None) {
+    fn add_entry_filetrans(domain source, resource default, [class]obj_classes, string name="") {
         /// Create a file-like object in this directory with a private type.
         /// This does not allow deletions from the directory.
         allow(source, this, dir, add_entry_dir_perms);
         resource_transition(source, this, obj_classes, default, name);
     }
 
-    fn filetrans(domain source, resource default, [class]obj_classes, string name=None) {
+    fn filetrans(domain source, resource default, [class]obj_classes, string name="") {
         /// Create a file-like object in this directory with a private type.
         allow(source, this, dir, rw_dir_perms);
         resource_transition(source, this, obj_classes, default, name);


### PR DESCRIPTION
While using rust-style option handling would be nice, it is not available in Cascade 0.1. Switch to "", which is processed by the Cascade builtins and converted to the appropriate CIL.